### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+devlib2 (2.9-2) unstable; urgency=medium
+
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Fri, 14 Sep 2018 14:07:39 -0400
+
 devlib2 (2.9-1) unstable; urgency=medium
 
   * New upstream version 2.9

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: devlib2
 Section: devel
 Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@bnl.gov>
-Build-Depends: debhelper (>= 7), epics-debhelper (>= 6~),
-               epics-dev (>= 3.14.11-2),
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 6~), epics-dev (>= 3.14.11-2),
                epics-msi,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme2307,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme2307 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics
 X-Epics-Targets: .*
 Standards-Version: 3.8.0
@@ -41,6 +41,7 @@ Description: VME and PCI bus access library
 
 
 Package: rtems-devlib2-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-devlib2-dev (>= ${binary:Version}),
          epics-devlib2-dev (<< ${binary:Version}.1~), ${misc:Depends},
@@ -53,6 +54,7 @@ Description: VME and PCI bus access library
  This package contains support for the MVME2100 PowerPC based VME SBC.
 
 Package: rtems-devlib2-mvme2307
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-devlib2-dev (>= ${binary:Version}),
          epics-devlib2-dev (<< ${binary:Version}.1~), ${misc:Depends},
@@ -65,6 +67,7 @@ Description: VME and PCI bus access library
  This package contains support for the MVME2307 PowerPC based VME SBC.
 
 Package: rtems-devlib2-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-devlib2-dev (>= ${binary:Version}),
          epics-devlib2-dev (<< ${binary:Version}.1~), ${misc:Depends},
@@ -77,6 +80,7 @@ Description: VME and PCI bus access library
  This package contains support for the MVME3100 PowerPC based VME SBC.
 
 Package: rtems-devlib2-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, epics-devlib2-dev (>= ${binary:Version}),
          epics-devlib2-dev (<< ${binary:Version}.1~), ${misc:Depends},

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,8 @@
+devlib2 source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-devlib2-mvme2100
+devlib2 source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-devlib2-mvme2307
+devlib2 source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-devlib2-mvme3100
+devlib2 source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-devlib2-mvme5500
+devlib2 source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+devlib2 source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2307 <pkg.epics-base.rtems>]
+devlib2 source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+devlib2 source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.